### PR TITLE
Feature/lib 52

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to NPM
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+      - name: Build lib
+        run: pnpm run build
+      - name: Build lib
+        run: pnpm run build
+      - uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{secrets.NONAME_LIBRARY}}
+          access: 'public'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ui-kit",
-  "private": true,
-  "version": "0.0.0",
+  "name": "@photo-fiesta/ui-lib",
+  "private": false,
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -17,7 +17,8 @@
     "generate-svg-components": "npx @svgr/cli --out-dir src/assets/icons/components --typescript  --icon --memo --ref --jsx-runtime automatic --replace-attr-values 'black=currentColor' -- src/assets/icons/svg && pnpm updateSvg && pnpm lint && pnpm format",
     "comp": "node scripts/create-component.mjs",
     "prepare": "husky install",
-    "pre-push": "pnpm format && pnpm run lint && pnpm run build"
+    "pre-push": "pnpm format && pnpm run lint && pnpm run build",
+    "bump": "npm version patch -m \"@photo-fiesta/ui-lib version updated to v%s\""
   },
   "comments": {
     "//": "script description",
@@ -25,7 +26,8 @@
       "sb": "storybook",
       "/": "usage: pnpm comp <folderName> <componentName> true",
       "comp": "generate folder with tsx,stories,scss templates",
-      "generate-svg-components": "generate tsx from svg"
+      "generate-svg-components": "generate tsx from svg",
+      "bump": "npm version patch -m \"@photo-fiesta/ui-lib version updated to v%s\""
     }
   },
   "main": "./dist/index.cjs",
@@ -43,6 +45,10 @@
       }
     },
     "./style.css": "./dist/style.css"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "dependencies": {
     "@fontsource/inter": "^5.0.20",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
     },
   },
   build: {
+    emptyOutDir: true,
+    outDir: './dist',
     target: 'esnext',
     minify: false,
     lib: {


### PR DESCRIPTION
# Preparing for Library Publication on NPM

## Changes

1. Updated `package.json`:
   - Added the `bump` script to increase the patch version of the library.
   - Added the `bump-and-commit` script to increase the version, create a commit, and push changes.
   - Updated comments for the new scripts.

2. Added `publish.yml` file for GitHub Actions:
   - Configured a workflow for manually publishing the library to NPM.
   - The workflow is triggered manually via `workflow_dispatch`.

## Purpose of Changes

These changes prepare our UI component library for publication on the NPM registry. They allow us to:

- Easily manage versioning of the library.
- Automate the process of publishing new versions.
- Control the timing of publication through manual execution of the GitHub Actions workflow.

## How to Use

1. To increase the version and create a commit:

`pnpm run bump`


2. To publish to NPM:
- Go to the "Actions" tab on GitHub.
- Select the "Publish to NPM" workflow.
- Click "Run workflow".

## Pre-Merge Checklist

- [ ] Verified access rights to the NPM registry.
- [ ] Checked the NPM token in the GitHub repository secrets.
- [ ] Tested the local build of the library.
- [ ] Updated documentation (if necessary).

## Next Steps

After merging this PR, we will be able to start publishing our library to NPM and use it in other projects.