### PR TITLE
feature/PROJ-169: add FormRadioGroup component

### DIFF
--- a/src/components/ui/controlled/formRadioGroup/formRadioGroup.tsx
+++ b/src/components/ui/controlled/formRadioGroup/formRadioGroup.tsx
@@ -1,0 +1,50 @@
+import { RadioGroup } from '@/components'
+import { FieldValues, useController, UseControllerProps } from 'react-hook-form'
+import { RadioGroupProps } from '@radix-ui/react-radio-group'
+
+/**
+ * Props for the FormRadioGroup component.
+ *
+ * @template TFieldValues - The type of field values managed by react-hook-form.
+ * @extends {UseControllerProps<TFieldValues>} - Inherits controller props from react-hook-form.
+ * @extends {Omit<RadioGroupProps, 'onBlur' | 'onChange' | 'value'>} - Omitted props from Radix UI RadioGroup.
+ */
+export type FormRadioGroupProps<TFieldValues extends FieldValues> =
+  UseControllerProps<TFieldValues> & Omit<RadioGroupProps, 'onBlur' | 'onChange' | 'value'>
+
+/**
+ * A controlled radio group component that integrates with react-hook-form.
+ *
+ * This component allows you to create a group of radio buttons that can be controlled
+ * through react-hook-form's controller.
+ *
+ * @example
+ * <FormRadioGroup control={control} name={"radioOption"} defaultValue={"option1"} disabled={'false'}>
+ *   <RadioGroupItem value="option1" />
+ *   <RadioGroupItem value="option2" />
+ *   <RadioGroupItem value="option3" />
+ * </FormRadioGroup>
+ */
+export const FormRadioGroup = <TFieldValues extends FieldValues>({
+  control,
+  defaultValue,
+  name,
+  disabled,
+  children,
+  ...restProps
+}: FormRadioGroupProps<TFieldValues>) => {
+  const {
+    field: { onChange, ...restField },
+  } = useController({
+    control,
+    name,
+    defaultValue,
+    disabled,
+  })
+
+  return (
+    <RadioGroup {...restProps} {...restField} onValueChange={onChange}>
+      {children}
+    </RadioGroup>
+  )
+}

--- a/src/components/ui/controlled/formRadioGroup/formRadioGroup.tsx
+++ b/src/components/ui/controlled/formRadioGroup/formRadioGroup.tsx
@@ -15,9 +15,6 @@ export type FormRadioGroupProps<TFieldValues extends FieldValues> =
 /**
  * A controlled radio group component that integrates with react-hook-form.
  *
- * This component allows you to create a group of radio buttons that can be controlled
- * through react-hook-form's controller.
- *
  * @example
  * <FormRadioGroup control={control} name={"radioOption"} defaultValue={"option1"} disabled={'false'}>
  *   <RadioGroupItem value="option1" />
@@ -34,7 +31,7 @@ export const FormRadioGroup = <TFieldValues extends FieldValues>({
   ...restProps
 }: FormRadioGroupProps<TFieldValues>) => {
   const {
-    field: { onChange, ...restField },
+    field: { onChange, ref, value,...restField },
   } = useController({
     control,
     name,
@@ -43,7 +40,7 @@ export const FormRadioGroup = <TFieldValues extends FieldValues>({
   })
 
   return (
-    <RadioGroup {...restProps} {...restField} onValueChange={onChange}>
+    <RadioGroup {...restProps} {...restField} ref={ref} value={value} onValueChange={onChange}>
       {children}
     </RadioGroup>
   )

--- a/src/components/ui/controlled/formRadioGroup/index.ts
+++ b/src/components/ui/controlled/formRadioGroup/index.ts
@@ -1,0 +1,1 @@
+export * from "./formRadioGroup"

--- a/src/components/ui/controlled/index.ts
+++ b/src/components/ui/controlled/index.ts
@@ -1,4 +1,5 @@
 export * from './formInput'
+export * from './formRadioGroup'
 export * from './formCheckbox'
 export * from './formTextArea'
 export * from './formSelect'

--- a/src/components/ui/pagination/pagination.stories.tsx
+++ b/src/components/ui/pagination/pagination.stories.tsx
@@ -78,7 +78,7 @@ export const PaginationWithSelect: Story = {
         pageSize={pageSize}
         totalCount={args.totalCount}
       >
-        <SelectContainer content={['Show', 'on page']}>
+        <SelectContainer content={['Show', 'on page'] as string[] & string}>
           <Select pagination onValueChange={handleOptionChange} value={option}>
             {options.map(option => (
               <SelectItem key={option.id} value={option.value}>


### PR DESCRIPTION
# add FormRadioGroup component

## **Overview**

This pull request introduces the FormRadioGroup component, a controlled radio group that integrates seamlessly with react-hook-form.

## Usage
Example usage in a form:

```
<FormRadioGroup control={control} name="radioOption" defaultValue="option1" disabled={false}>
  <RadioGroupItem value="option1" />
  <RadioGroupItem value="option2" />
  <RadioGroupItem value="option3" />
</FormRadioGroup>
```



