### PR TITLE
feature/PROJ-172: fix according to comments to PR 64

### DIFF
--- a/src/components/ui/dropdown/dropdown.module.scss
+++ b/src/components/ui/dropdown/dropdown.module.scss
@@ -24,7 +24,8 @@ button {
 }
 
 .dropdownMenuContent {
-  width: 355px;
+  width: 100%;
+  max-width: 355px;
   height: fit-content;
   padding: 3px 0 15px 15px;
 

--- a/src/components/ui/dropdown/dropdown.module.scss
+++ b/src/components/ui/dropdown/dropdown.module.scss
@@ -25,6 +25,7 @@ button {
 
 .dropdownMenuContent {
   width: 100%;
+  min-width: 173px;
   max-width: 355px;
   height: fit-content;
   padding: 3px 0 15px 15px;
@@ -42,7 +43,6 @@ button {
 }
 
 .scroll {
-  height: 367px;
   margin-right: 7px;
 }
 

--- a/src/components/ui/dropdown/dropdown.stories.tsx
+++ b/src/components/ui/dropdown/dropdown.stories.tsx
@@ -17,23 +17,23 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+const itemExample = (
+  <>
+    <Typography variant={'textBold14'} as={'span'}>
+      Новое уведомление!
+    </Typography>
+    <Typography variant={'textSmall'} as={'span'} style={{ color: 'var(--accent-500)' }}>
+      {' Новое'}
+    </Typography>
+    <Typography variant={'textSmall'}>Следующий платеж у вас спишется через 1 день</Typography>
+    <Typography variant={'textSmall'} style={{ color: 'var(--light-900)' }}>
+      1 час назад
+    </Typography>
+  </>
+)
+
 export const DropdownMenuWithScroll: Story = {
   render: () => {
-    const itemExample = (
-      <>
-        <Typography variant={'textBold14'} as={'span'}>
-          Новое уведомление!
-        </Typography>
-        <Typography variant={'textSmall'} as={'span'} style={{ color: 'var(--accent-500)' }}>
-          {' Новое'}
-        </Typography>
-        <Typography variant={'textSmall'}>Следующий платеж у вас спишется через 1 день</Typography>
-        <Typography variant={'textSmall'} style={{ color: 'var(--light-900)' }}>
-          1 час назад
-        </Typography>
-      </>
-    )
-
     return (
       <DropdownMenu>
         <DropdownMenuTrigger>
@@ -47,6 +47,36 @@ export const DropdownMenuWithScroll: Story = {
           <DropdownMenuItem>{itemExample}</DropdownMenuItem>
           <DropdownMenuItem>{itemExample}</DropdownMenuItem>
           <DropdownMenuItem>{itemExample}</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+  },
+}
+
+export const DropdownMenuWithoutScroll: Story = {
+  render: () => {
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger>
+          <FillBell color={'var(--accent-500)'} width={'24px'} height={'24px'} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent label={'Уведомления'}>
+          <DropdownMenuItem>{itemExample}</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+  },
+}
+
+export const DropdownMenuEmpty: Story = {
+  render: () => {
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger>
+          <FillBell color={'var(--accent-500)'} width={'24px'} height={'24px'} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent label={'Уведомления'}>
+          {/*<DropdownMenuItem>{itemExample}</DropdownMenuItem>*/}
         </DropdownMenuContent>
       </DropdownMenu>
     )

--- a/src/components/ui/dropdown/dropdown.tsx
+++ b/src/components/ui/dropdown/dropdown.tsx
@@ -1,9 +1,9 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import styles from './dropdown.module.scss'
-import {clsx} from 'clsx'
-import {ComponentPropsWithoutRef, ElementRef, forwardRef} from 'react'
-import s from '@/components/ui/dropdown/dropdown.module.scss'
-import {Scroll} from '@/components'
+import { clsx } from 'clsx'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
+import s from './dropdown.module.scss'
+import { Scroll } from '@/components'
 
 /**
  * The root component for the dropdown menu.
@@ -28,23 +28,23 @@ export const DropdownMenu = DropdownMenuPrimitive.Root
  * <DropdownMenuTrigger className="custom-class"> Trigger </DropdownMenuTrigger>
  */
 export const DropdownMenuTrigger = forwardRef<
-    ElementRef<typeof DropdownMenuPrimitive.Trigger>,
-    ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
->(({className, children, ...restProps}, ref) => {
-    const classNames = {
-        dropdownMenuTrigger: clsx(styles.dropdownMenuTrigger, className),
-    } as const
+  ElementRef<typeof DropdownMenuPrimitive.Trigger>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
+>(({ className, children, ...restProps }, ref) => {
+  const classNames = {
+    dropdownMenuTrigger: clsx(styles.dropdownMenuTrigger, className),
+  } as const
 
-    return (
-        <DropdownMenuPrimitive.Trigger
-            asChild
-            ref={ref}
-            className={classNames.dropdownMenuTrigger}
-            {...restProps}
-        >
-            <button aria-label="Customise options">{children}</button>
-        </DropdownMenuPrimitive.Trigger>
-    )
+  return (
+    <DropdownMenuPrimitive.Trigger
+      asChild
+      ref={ref}
+      className={classNames.dropdownMenuTrigger}
+      {...restProps}
+    >
+      <button aria-label="Customise options">{children}</button>
+    </DropdownMenuPrimitive.Trigger>
+  )
 })
 DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName
 
@@ -55,7 +55,7 @@ DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName
  * @extends {ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>}
  */
 type DropdownMenuContent = {
-    label?: string
+  label?: string
 } & ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 
 /**
@@ -71,37 +71,33 @@ type DropdownMenuContent = {
  * </DropdownMenuContent>
  */
 export const DropdownMenuContent = forwardRef<
-    ElementRef<typeof DropdownMenuPrimitive.Content>,
-    DropdownMenuContent
->(({label, className, sideOffset = 3, children, ...restProps}, ref) => {
-    const classNames = {
-        dropdownMenuContent: clsx(styles.dropdownMenuContent, className),
-        dropdownMenuArrowBack: clsx(styles.dropdownMenuArrow, styles.backArrow),
-        dropdownMenuArrowFront: clsx(styles.dropdownMenuArrow, styles.frontArrow),
-        dropdownMenuLabel: clsx(styles.dropdownMenuLabel, className),
-        labelSeparator: styles.labelSeparator,
-    } as const
+  ElementRef<typeof DropdownMenuPrimitive.Content>,
+  DropdownMenuContent
+>(({ label, className, sideOffset = 3, children, ...restProps }, ref) => {
+  const classNames = {
+    dropdownMenuContent: clsx(styles.dropdownMenuContent, className),
+    dropdownMenuArrowBack: clsx(styles.dropdownMenuArrow, styles.backArrow),
+    dropdownMenuArrowFront: clsx(styles.dropdownMenuArrow, styles.frontArrow),
+    dropdownMenuLabel: clsx(styles.dropdownMenuLabel, className),
+    labelSeparator: styles.labelSeparator,
+  } as const
 
-    return (
-        <DropdownMenuPrimitive.Portal>
-            <DropdownMenuPrimitive.Content
-                ref={ref}
-                sideOffset={sideOffset}
-                className={classNames.dropdownMenuContent}
-                {...restProps}
-            >
-                <DropdownMenuPrimitive.Arrow className={classNames.dropdownMenuArrowBack}/>
-                <DropdownMenuPrimitive.Arrow className={classNames.dropdownMenuArrowFront}/>
-                <DropdownMenuLabel
-                    className={classNames.dropdownMenuLabel}
-                >
-                    {label}
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator className={classNames.labelSeparator}/>
-                <Scroll className={s.scroll}>{children}</Scroll>
-            </DropdownMenuPrimitive.Content>
-        </DropdownMenuPrimitive.Portal>
-    )
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={classNames.dropdownMenuContent}
+        {...restProps}
+      >
+        <DropdownMenuPrimitive.Arrow className={classNames.dropdownMenuArrowBack} />
+        <DropdownMenuPrimitive.Arrow className={classNames.dropdownMenuArrowFront} />
+        <DropdownMenuLabel className={classNames.dropdownMenuLabel}>{label}</DropdownMenuLabel>
+        <DropdownMenuSeparator className={classNames.labelSeparator} />
+        <Scroll className={s.scroll}>{children}</Scroll>
+      </DropdownMenuPrimitive.Content>
+    </DropdownMenuPrimitive.Portal>
+  )
 })
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
@@ -112,26 +108,26 @@ DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
  * <DropdownMenuLabel inset> Label </DropdownMenuLabel>
  */
 const DropdownMenuLabel = forwardRef<
-    ElementRef<typeof DropdownMenuPrimitive.Label>,
-    ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+  ElementRef<typeof DropdownMenuPrimitive.Label>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
     inset?: boolean
-}
->(({className, ...restProps}, ref) => {
-    const classNames = {
-        dropdownMenuLabel: clsx(styles.dropdownMenuLabel, className),
-        labelSeparator: styles.labelSeparator,
-    } as const
+  }
+>(({ className, ...restProps }, ref) => {
+  const classNames = {
+    dropdownMenuLabel: clsx(styles.dropdownMenuLabel, className),
+    labelSeparator: styles.labelSeparator,
+  } as const
 
-    return (
-        <>
-            <DropdownMenuPrimitive.Label
-                ref={ref}
-                className={classNames.dropdownMenuLabel}
-                {...restProps}
-            />
-            <DropdownMenuSeparator className={classNames.labelSeparator}/>
-        </>
-    )
+  return (
+    <>
+      <DropdownMenuPrimitive.Label
+        ref={ref}
+        className={classNames.dropdownMenuLabel}
+        {...restProps}
+      />
+      <DropdownMenuSeparator className={classNames.labelSeparator} />
+    </>
+  )
 })
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
 
@@ -142,23 +138,23 @@ DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
  * <DropdownMenuItem> Item </DropdownMenuItem>
  */
 export const DropdownMenuItem = forwardRef<
-    ElementRef<typeof DropdownMenuPrimitive.Item>,
-    ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
->(({className, ...restProps}, ref) => {
-    const classNames = {
-        dropdownMenuItem: clsx(styles.dropdownMenuItem, className),
-    } as const
+  ElementRef<typeof DropdownMenuPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({ className, ...restProps }, ref) => {
+  const classNames = {
+    dropdownMenuItem: clsx(styles.dropdownMenuItem, className),
+  } as const
 
-    return (
-        <>
-            <DropdownMenuPrimitive.Item
-                ref={ref}
-                className={classNames.dropdownMenuItem}
-                {...restProps}
-            />
-            <DropdownMenuSeparator/>
-        </>
-    )
+  return (
+    <>
+      <DropdownMenuPrimitive.Item
+        ref={ref}
+        className={classNames.dropdownMenuItem}
+        {...restProps}
+      />
+      <DropdownMenuSeparator />
+    </>
+  )
 })
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
@@ -169,19 +165,19 @@ DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
  * <DropdownMenuSeparator />
  */
 const DropdownMenuSeparator = forwardRef<
-    ElementRef<typeof DropdownMenuPrimitive.Separator>,
-    ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({className, ...props}, ref) => {
-    const classNames = {
-        dropdownMenuSeparator: clsx(styles.dropdownMenuSeparator, className),
-    } as const
+  ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => {
+  const classNames = {
+    dropdownMenuSeparator: clsx(styles.dropdownMenuSeparator, className),
+  } as const
 
-    return (
-        <DropdownMenuPrimitive.Separator
-            ref={ref}
-            className={classNames.dropdownMenuSeparator}
-            {...props}
-        />
-    )
+  return (
+    <DropdownMenuPrimitive.Separator
+      ref={ref}
+      className={classNames.dropdownMenuSeparator}
+      {...props}
+    />
+  )
 })
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName

--- a/src/components/ui/dropdown/dropdown.tsx
+++ b/src/components/ui/dropdown/dropdown.tsx
@@ -1,9 +1,9 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import styles from './dropdown.module.scss'
-import { clsx } from 'clsx'
-import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
+import {clsx} from 'clsx'
+import {ComponentPropsWithoutRef, ElementRef, forwardRef} from 'react'
 import s from '@/components/ui/dropdown/dropdown.module.scss'
-import { Scroll } from '@/components'
+import {Scroll} from '@/components'
 
 /**
  * The root component for the dropdown menu.
@@ -28,23 +28,23 @@ export const DropdownMenu = DropdownMenuPrimitive.Root
  * <DropdownMenuTrigger className="custom-class"> Trigger </DropdownMenuTrigger>
  */
 export const DropdownMenuTrigger = forwardRef<
-  ElementRef<typeof DropdownMenuPrimitive.Trigger>,
-  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
->(({ className, children, ...restProps }, forwardedRef) => {
-  const classNames = {
-    dropdownMenuTrigger: clsx(styles.dropdownMenuTrigger, className),
-  } as const
+    ElementRef<typeof DropdownMenuPrimitive.Trigger>,
+    ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
+>(({className, children, ...restProps}, ref) => {
+    const classNames = {
+        dropdownMenuTrigger: clsx(styles.dropdownMenuTrigger, className),
+    } as const
 
-  return (
-    <DropdownMenuPrimitive.Trigger
-      asChild
-      ref={forwardedRef}
-      className={classNames.dropdownMenuTrigger}
-      {...restProps}
-    >
-      <button aria-label="Customise options">{children}</button>
-    </DropdownMenuPrimitive.Trigger>
-  )
+    return (
+        <DropdownMenuPrimitive.Trigger
+            asChild
+            ref={ref}
+            className={classNames.dropdownMenuTrigger}
+            {...restProps}
+        >
+            <button aria-label="Customise options">{children}</button>
+        </DropdownMenuPrimitive.Trigger>
+    )
 })
 DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName
 
@@ -55,7 +55,7 @@ DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName
  * @extends {ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>}
  */
 type DropdownMenuContent = {
-  label?: string
+    label?: string
 } & ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 
 /**
@@ -64,46 +64,44 @@ type DropdownMenuContent = {
  * ! Attention: label should be set as props of DropdownMenuItem
  *
  * @example
- * <DropdownMenuContent>
- *   <DropdownMenuItem label={'Label'}> Item1 </DropdownMenuItem>
+ * <DropdownMenuContent label={'Label'}>
+ *   <DropdownMenuItem> Item1 </DropdownMenuItem>
  *   <DropdownMenuItem> Item2 </DropdownMenuItem>
  *   <DropdownMenuItem> Item3 </DropdownMenuItem>
  * </DropdownMenuContent>
  */
 export const DropdownMenuContent = forwardRef<
-  ElementRef<typeof DropdownMenuPrimitive.Content>,
-  DropdownMenuContent
->(({ label, className, sideOffset = 3, children, ...restProps }, forwardedRef) => {
-  const classNames = {
-    dropdownMenuContent: clsx(styles.dropdownMenuContent, className),
-    dropdownMenuArrowBack: clsx(styles.dropdownMenuArrow, styles.backArrow),
-    dropdownMenuArrowFront: clsx(styles.dropdownMenuArrow, styles.frontArrow),
-    dropdownMenuLabel: clsx(styles.dropdownMenuLabel, className),
-    labelSeparator: styles.labelSeparator,
-  } as const
+    ElementRef<typeof DropdownMenuPrimitive.Content>,
+    DropdownMenuContent
+>(({label, className, sideOffset = 3, children, ...restProps}, ref) => {
+    const classNames = {
+        dropdownMenuContent: clsx(styles.dropdownMenuContent, className),
+        dropdownMenuArrowBack: clsx(styles.dropdownMenuArrow, styles.backArrow),
+        dropdownMenuArrowFront: clsx(styles.dropdownMenuArrow, styles.frontArrow),
+        dropdownMenuLabel: clsx(styles.dropdownMenuLabel, className),
+        labelSeparator: styles.labelSeparator,
+    } as const
 
-  return (
-    <DropdownMenuPrimitive.Portal>
-      <DropdownMenuPrimitive.Content
-        ref={forwardedRef}
-        sideOffset={sideOffset}
-        className={classNames.dropdownMenuContent}
-        {...restProps}
-      >
-        <DropdownMenuPrimitive.Arrow className={classNames.dropdownMenuArrowBack} />
-        <DropdownMenuPrimitive.Arrow className={classNames.dropdownMenuArrowFront} />
-        <DropdownMenuPrimitive.Label
-          ref={forwardedRef}
-          className={classNames.dropdownMenuLabel}
-          {...restProps}
-        >
-          {label}
-        </DropdownMenuPrimitive.Label>
-        <DropdownMenuSeparator className={classNames.labelSeparator} />
-        <Scroll className={s.scroll}>{children}</Scroll>
-      </DropdownMenuPrimitive.Content>
-    </DropdownMenuPrimitive.Portal>
-  )
+    return (
+        <DropdownMenuPrimitive.Portal>
+            <DropdownMenuPrimitive.Content
+                ref={ref}
+                sideOffset={sideOffset}
+                className={classNames.dropdownMenuContent}
+                {...restProps}
+            >
+                <DropdownMenuPrimitive.Arrow className={classNames.dropdownMenuArrowBack}/>
+                <DropdownMenuPrimitive.Arrow className={classNames.dropdownMenuArrowFront}/>
+                <DropdownMenuLabel
+                    className={classNames.dropdownMenuLabel}
+                >
+                    {label}
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator className={classNames.labelSeparator}/>
+                <Scroll className={s.scroll}>{children}</Scroll>
+            </DropdownMenuPrimitive.Content>
+        </DropdownMenuPrimitive.Portal>
+    )
 })
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
@@ -114,26 +112,26 @@ DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
  * <DropdownMenuLabel inset> Label </DropdownMenuLabel>
  */
 const DropdownMenuLabel = forwardRef<
-  ElementRef<typeof DropdownMenuPrimitive.Label>,
-  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    ElementRef<typeof DropdownMenuPrimitive.Label>,
+    ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
     inset?: boolean
-  }
->(({ className, ...restProps }, forwardedRef) => {
-  const classNames = {
-    dropdownMenuLabel: clsx(styles.dropdownMenuLabel, className),
-    labelSeparator: styles.labelSeparator,
-  } as const
+}
+>(({className, ...restProps}, ref) => {
+    const classNames = {
+        dropdownMenuLabel: clsx(styles.dropdownMenuLabel, className),
+        labelSeparator: styles.labelSeparator,
+    } as const
 
-  return (
-    <>
-      <DropdownMenuPrimitive.Label
-        ref={forwardedRef}
-        className={classNames.dropdownMenuLabel}
-        {...restProps}
-      />
-      <DropdownMenuSeparator className={classNames.labelSeparator} />
-    </>
-  )
+    return (
+        <>
+            <DropdownMenuPrimitive.Label
+                ref={ref}
+                className={classNames.dropdownMenuLabel}
+                {...restProps}
+            />
+            <DropdownMenuSeparator className={classNames.labelSeparator}/>
+        </>
+    )
 })
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
 
@@ -144,23 +142,23 @@ DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
  * <DropdownMenuItem> Item </DropdownMenuItem>
  */
 export const DropdownMenuItem = forwardRef<
-  ElementRef<typeof DropdownMenuPrimitive.Item>,
-  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
->(({ className, ...restProps }, ref) => {
-  const classNames = {
-    dropdownMenuItem: clsx(styles.dropdownMenuItem, className),
-  } as const
+    ElementRef<typeof DropdownMenuPrimitive.Item>,
+    ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({className, ...restProps}, ref) => {
+    const classNames = {
+        dropdownMenuItem: clsx(styles.dropdownMenuItem, className),
+    } as const
 
-  return (
-    <>
-      <DropdownMenuPrimitive.Item
-        ref={ref}
-        className={classNames.dropdownMenuItem}
-        {...restProps}
-      />
-      <DropdownMenuSeparator />
-    </>
-  )
+    return (
+        <>
+            <DropdownMenuPrimitive.Item
+                ref={ref}
+                className={classNames.dropdownMenuItem}
+                {...restProps}
+            />
+            <DropdownMenuSeparator/>
+        </>
+    )
 })
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
@@ -171,19 +169,19 @@ DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
  * <DropdownMenuSeparator />
  */
 const DropdownMenuSeparator = forwardRef<
-  ElementRef<typeof DropdownMenuPrimitive.Separator>,
-  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => {
-  const classNames = {
-    dropdownMenuSeparator: clsx(styles.dropdownMenuSeparator, className),
-  } as const
+    ElementRef<typeof DropdownMenuPrimitive.Separator>,
+    ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({className, ...props}, ref) => {
+    const classNames = {
+        dropdownMenuSeparator: clsx(styles.dropdownMenuSeparator, className),
+    } as const
 
-  return (
-    <DropdownMenuPrimitive.Separator
-      ref={ref}
-      className={classNames.dropdownMenuSeparator}
-      {...props}
-    />
-  )
+    return (
+        <DropdownMenuPrimitive.Separator
+            ref={ref}
+            className={classNames.dropdownMenuSeparator}
+            {...props}
+        />
+    )
 })
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName

--- a/src/components/ui/scroll/scroll.module.scss
+++ b/src/components/ui/scroll/scroll.module.scss
@@ -1,3 +1,7 @@
+@mixin background-transition {
+  transition: background-color 300ms ease-out;
+}
+
 .root {
   overflow: hidden;
 }
@@ -19,7 +23,7 @@
   background: var(--dark-300);
   border-radius: 2px;
 
-  transition: background-color 300ms ease-out;
+  @include background-transition;
 }
 
 .scrollbar[data-orientation='vertical'] {
@@ -43,7 +47,7 @@
   background-color: var(--dark-100);
   border-radius: 2px;
 
-  transition: background-color 300ms ease-out;
+  @include background-transition;
 }
 
 .thumb:hover {

--- a/src/components/ui/scroll/scroll.module.scss
+++ b/src/components/ui/scroll/scroll.module.scss
@@ -1,6 +1,4 @@
-@mixin background-transition {
-  transition: background-color 300ms ease-out;
-}
+@use '@/styles/mixins' as *;
 
 .root {
   overflow: hidden;
@@ -9,6 +7,7 @@
 .viewport {
   width: 100%;
   height: 100%;
+  max-height: 357px;
 }
 
 .scrollbar {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -49,3 +49,7 @@
 
   @include font(var(--font-size-m), var(--line-height-m), var(--font-weight-semibold));
 }
+
+@mixin background-transition {
+  transition: background-color 300ms ease-out;
+}


### PR DESCRIPTION
# Changes according to the comments to pull request 64 

# Overview of pull request 64 

The pull request 64 introduces a set of components for building a customizable dropdown menu using @radix-ui/react-dropdown-menu primitives.

## The PR includes the following components:

**DropdownMenu:** Root component for the dropdown.
**DropdownMenuTrigger:** Component that triggers the dropdown menu.
**DropdownMenuContent:** Wrapper for the dropdown items, supporting an optional label prop.
**DropdownMenuItem:** Component for individual dropdown menu items.

# Usage
Example usage
``` 
<DropdownMenu>
  <DropdownMenuTrigger> Trigger </DropdownMenuTrigger>
  <DropdownMenuContent label={'Label'}>
    <DropdownMenuItem> Item1 </DropdownMenuItem>
    <DropdownMenuItem> Item2 </DropdownMenuItem>
    <DropdownMenuItem> Item3 </DropdownMenuItem>
  </DropdownMenuContent>
</DropdownMenu>
```
<img width="386" alt="image" src="https://github.com/user-attachments/assets/a6cc690d-9714-4758-ad93-b23cc70a0db0">